### PR TITLE
Bump AspNet.Security.OAuth.Apple to 6.0.10

### DIFF
--- a/src/AvantiPoint.MobileAuth/AvantiPoint.MobileAuth.csproj
+++ b/src/AvantiPoint.MobileAuth/AvantiPoint.MobileAuth.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="AspNet.Security.OAuth.Apple" Version="6.0.6" />
+    <PackageReference Include="AspNet.Security.OAuth.Apple" Version="6.0.10" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="6.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.6" />


### PR DESCRIPTION
Resolves https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/security/advisories/GHSA-3893-h8qg-6h5f.

I found this repository through our dependency graph:

![image](https://user-images.githubusercontent.com/1439341/188144879-2bed24b5-0d18-471b-9ce5-1eb5d5adcc9a.png)
